### PR TITLE
Limited count of claims from IP during some period of time.

### DIFF
--- a/corruption_tracker/settings.py
+++ b/corruption_tracker/settings.py
@@ -142,6 +142,11 @@ LEAFLET_CONFIG = {
 
 }
 
+MEMCACHED_HOST = ('127.0.0.1', 11211)
+
+# How much claims can be sent from uniq IP during CLAIM_TIMEOUT_PERIOD.
+CLAIMS_PER_HOUR = 3
+CLAIM_TIMEOUT_PERIOD = 3600
 
 try:
     from .local_settings import *

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ django-leaflet==0.16.0
 djangorestframework==3.1.3
 django-allauth==0.23.0
 requests==2.7.0
+python-memcached==1.57


### PR DESCRIPTION
Reason to use memcached:
We need only small piece of information during pretty small
period of time. There is two other ways to keep it:
- Database // we don't need percistant stor, and lets
          // keed DB as clean as possible
- Memory   // we can move cache here, but with MCD
          // we can move caching to sepparate host,
          // or even few if needed.
