### PR TITLE
add v1.1 api calls

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -25,7 +25,7 @@ class ClaimTypeSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = ClaimType
-        fields = ('id', 'name', 'org_type', 'icon')
+        fields = ('id', 'name', 'icon')
 
 
 def extractor(polygon_id):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -21,6 +21,7 @@ class OrganizationSerializer(serializers.ModelSerializer):
         fields = ('id', 'name', 'org_type', 'total_claims')
 
 
+
 class ClaimTypeSerializer(serializers.ModelSerializer):
 
     class Meta:

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -7,6 +7,10 @@ from geoinfo.models import Polygon
 
 class ClaimSerializer(serializers.ModelSerializer):
 
+
+    complainer = serializers.ReadOnlyField(source='complainer.username')
+    created = serializers.ReadOnlyField()
+
     class Meta:
         model = Claim
         fields = ('text', 'created', 'live', 'organization',
@@ -16,9 +20,13 @@ class ClaimSerializer(serializers.ModelSerializer):
 
 class OrganizationSerializer(serializers.ModelSerializer):
 
+    # claims = serializers.PrimaryKeyRelatedField(many=True, queryset=Claim.objects.all())
+
     class Meta:
         model = Organization
-        fields = ('id', 'name', 'org_type', 'total_claims')
+        fields = ('id', 'name', 'org_type', 'total_claims', 
+            # 'claims'
+            'json_claims', 'claim_types')
 
 
 

--- a/api/urls.py
+++ b/api/urls.py
@@ -5,6 +5,21 @@ from rest_framework.routers import DefaultRouter
 
 from api import views, views_1_1
 
+# from rest_framework.decorators import api_view
+# from rest_framework.response import Response
+# from rest_framework.reverse import reverse
+
+
+# @api_view(('GET',))
+# def api_root(request, format=None):
+#     return Response({
+#         'get_polygons_tree': reverse('get_polygons_tree', request=request, format=format),
+#         'get_nearest_polygons': reverse('get_nearest_polygons', request=request, format=format),
+#         'check_in_building': reverse('check_in_building', request=request, format=format)
+#     })
+
+
+
 router = DefaultRouter()
 
 # -----   v1 api
@@ -14,6 +29,7 @@ router.register(r'v1/claim_types', views.ClaimTypeViewSet)
 
 
 urlpatterns = [
+	# url(r'^v1/$', api_root),
     url(r'^api-auth/', include('rest_framework.urls',
         namespace='rest_framework')),
     url(r'^v1/token/', obtain_auth_token, name='api-token'),

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,5 +1,5 @@
 
-from django.conf.urls import url
+from django.conf.urls import url, include
 from rest_framework.authtoken.views import obtain_auth_token
 from rest_framework.routers import DefaultRouter
 
@@ -14,8 +14,8 @@ router.register(r'v1/claim_types', views.ClaimTypeViewSet)
 
 
 urlpatterns = [
-    # url(r'^api-auth/', include('rest_framework.urls',
-    #     namespace='rest_framework')),
+    url(r'^api-auth/', include('rest_framework.urls',
+        namespace='rest_framework')),
     url(r'^v1/token/', obtain_auth_token, name='api-token'),
     url(r'^v1/get_polygons_tree/(?P<polygon_id>[\w.]{0,256})/$',
         views.get_polygons_tree, name="get_polygons_tree"),

--- a/api/urls.py
+++ b/api/urls.py
@@ -32,6 +32,6 @@ router.register(r'v1.1/claim_types', views_1_1.ClaimTypeViewSet, base_name='clai
 router.register(r'v1.1/get_polygons_tree', views_1_1.GetPolygonsTree, base_name='get_polygons_tree')
 router.register(r'v1.1/get_nearest_polygons', views_1_1.GetNearestPolygons, base_name='get_nearest_polygons')
 router.register(r'v1.1/check_in_polygon', views_1_1.CheckInPolygon, base_name='check_in_polygon')
-
+router.register(r'v1.1/add_organization', views_1_1.AddOrganization, base_name='add_organization')
 
 urlpatterns += router.urls

--- a/api/urls.py
+++ b/api/urls.py
@@ -3,9 +3,11 @@ from django.conf.urls import url
 from rest_framework.authtoken.views import obtain_auth_token
 from rest_framework.routers import DefaultRouter
 
-from api import views
+from api import views, views_1_1
 
 router = DefaultRouter()
+
+# -----   v1 api
 router.register(r'v1/claims', views.ClaimViewSet)
 router.register(r'v1/organizations', views.OrganizationViewSet)
 router.register(r'v1/claim_types', views.ClaimTypeViewSet)
@@ -22,5 +24,14 @@ urlpatterns = [
     url(r'^v1/check_in_building/(?P<layer>\d+)/(?P<coord>.*)$',
         views.check_in_building, name="check_in_building"),
 ]
+
+# ----    v1.1 api
+router.register(r'v1.1/claims', views_1_1.ClaimViewSet, base_name='claims')
+router.register(r'v1.1/organizations', views_1_1.OrganizationViewSet, base_name='organizations')
+router.register(r'v1.1/claim_types', views_1_1.ClaimTypeViewSet, base_name='claim_types')
+router.register(r'v1.1/get_polygons_tree', views_1_1.GetPolygonsTree, base_name='get_polygons_tree')
+router.register(r'v1.1/get_nearest_polygons', views_1_1.GetNearestPolygons, base_name='get_nearest_polygons')
+router.register(r'v1.1/check_in_polygon', views_1_1.CheckInPolygon, base_name='check_in_polygon')
+
 
 urlpatterns += router.urls

--- a/api/views.py
+++ b/api/views.py
@@ -78,7 +78,6 @@ def get_polygons_tree(request, polygon_id):
 
 def get_nearest_polygons(request, layer, distance, coord):
     pnt = fromstr("POINT(%s %s)" % tuple(coord.split(',')))
-    # pnt.transform(900913)
     selected = Polygon.objects.filter(
         centroid__dwithin=(pnt, float(distance)), level=int(layer))
 

--- a/api/views_1_1.py
+++ b/api/views_1_1.py
@@ -1,0 +1,169 @@
+import json
+
+from django.http import HttpResponse
+from django.utils.safestring import mark_safe
+from django.contrib.gis.geos import fromstr
+from rest_framework import viewsets, filters
+from rest_framework.permissions import BasePermission, SAFE_METHODS
+from rest_framework.response import Response
+
+from geoinfo.models import Polygon
+from claim.models import Claim, Organization,\
+    ClaimType
+from api.serializers import ClaimSerializer,\
+    OrganizationSerializer, ClaimTypeSerializer, extractor
+
+
+class IsSafe(BasePermission):
+    def has_object_permission(self, request, view, obj):
+        if request.method in SAFE_METHODS:
+            return True
+
+    def has_permission(self, request, view):
+        if request.method in SAFE_METHODS:
+            return True
+
+
+class CanPost(BasePermission):
+    def has_object_permission(self, request, view, obj):
+        if request.method in SAFE_METHODS + ('POST',):
+            return True
+
+    def has_permission(self, request, view):
+        if request.method in SAFE_METHODS + ('POST',):
+            return True
+
+
+class ClaimViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint for listing and creating Claims.
+    - to add claim use POST request
+    - to get claims for organization, use .../claims/_org_id_
+    Example:  .../claims/13/
+    """
+
+    queryset = Claim.objects.all()
+    serializer_class = ClaimSerializer
+    permission_classes = (CanPost,)
+
+    filter_backends = (
+        filters.OrderingFilter,
+    )
+    ordering_fields = ('created', )
+
+    def list(self, request):
+        docs = {ind:x for ind, x in enumerate(self.__doc__.split('\n')) if x }
+        return Response(docs)
+
+    def retrieve(self, request, pk=None):
+        queryset = Claim.objects.filter(organization__id=pk)   
+        serializer = ClaimSerializer(queryset, many=True)
+        return Response(serializer.data)        
+
+
+class OrganizationViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint for listing Organizations.
+    - to get organizations for polygon, use .../organizations/_polygon_id_
+    Example:  .../organizations/21citzhovt0002/
+    """
+
+    queryset = Organization.objects.all()
+    permission_classes = (IsSafe,)
+
+    def list(self, request):
+        docs = {ind:x for ind, x in enumerate(self.__doc__.split('\n')) if x }
+        return Response(docs)
+
+    def retrieve(self, request, pk=None):
+        queryset = Organization.objects.filter(polygon__polygon_id=pk)   
+        serializer = OrganizationSerializer(queryset, many=True)
+        return Response(serializer.data)
+
+
+
+class ClaimTypeViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint for listing ClaimTypes.
+    - to get claim types for organization type, use .../claim_types/_org_type_id_
+    Example:  .../claim_types/CNAP/
+    """
+
+    queryset = ClaimType.objects.all()
+    permission_classes = (IsSafe,)
+
+    def list(self, request):
+        docs = {ind:x for ind, x in enumerate(self.__doc__.split('\n')) if x }
+        return Response(docs)
+
+    def retrieve(self, request, pk=None):
+        queryset = ClaimType.objects.filter(org_type__type_id=pk)   
+        serializer = ClaimTypeSerializer(queryset, many=True)
+        return Response(serializer.data)
+
+
+
+class GetPolygonsTree(viewsets.ViewSet):
+    """
+    API endpoint for getting polygons ierarchy.
+    - GET returns hole tree from 'root' polygon
+    - to get tree from certain node, use .../get_polygons_tree/_polygon_id_
+    Example:  .../get_polygons_tree/21citdzerz/
+    """
+
+    def list(self, request):
+        return Response(extractor('root'))
+
+    def retrieve(self, request, pk='root'):     
+        return Response(extractor(pk))
+
+    queryset = Polygon.objects.all()
+    permission_classes = (IsSafe,)
+
+
+class GetNearestPolygons(viewsets.ViewSet):
+    """
+    API endpoint for getting nearest polygons.  
+    - to get nearest polygons, use .../get_nearest_polygons/_layer_distance_lat_lang_
+    Example:  .../get_nearest_polygons/4_0,05_36,226147_49,986106/
+    """
+
+    def list(self, request):
+        docs = {ind:x for ind, x in enumerate(self.__doc__.split('\n')) if x }
+        return Response(docs)
+
+    def retrieve(self, request, pk=None):
+        layer, distance, lat, lang = tuple(pk.split('_'))
+        pnt = fromstr("POINT(%s %s)" % (lat.replace(',', '.'), lang.replace(',', '.')))
+        selected = Polygon.objects.filter(
+            centroid__dwithin=(pnt, float(distance.replace(',', '.'))), level=int(layer))
+
+        data = [x.polygon_to_json() for x in selected]
+        return Response(data)
+
+    queryset = Polygon.objects.all()
+    permission_classes = (IsSafe,)
+
+
+class CheckInPolygon(viewsets.ViewSet):
+    """
+    API endpoint for check in polygon.  
+    - to check in polygon, use .../check_in_polygon/_layer_lat_lang_
+    Example:  .../check_in_polygon/4_36,2218621_49,9876059/
+    """
+
+    def list(self, request):
+        docs = {ind:x for ind, x in enumerate(self.__doc__.split('\n')) if x }
+        return Response(docs)
+
+    def retrieve(self, request, pk='root'):   
+        layer, lat, lang = tuple(pk.split('_'))  
+        pnt = fromstr("POINT(%s %s)" % (lat.replace(',', '.'), lang.replace(',', '.')))
+        selected = Polygon.objects.filter(shape__contains=pnt, level=int(layer))
+
+        data = [x.polygon_to_json() for x in selected]
+        return Response(data)
+
+    queryset = Polygon.objects.all()
+    permission_classes = (IsSafe,)
+

--- a/api/views_1_1.py
+++ b/api/views_1_1.py
@@ -71,7 +71,13 @@ class ClaimViewSet(viewsets.ModelViewSet):
     def retrieve(self, request, pk=None):
         queryset = Claim.objects.filter(organization__id=pk)   
         serializer = ClaimSerializer(queryset, many=True)
-        return Response(serializer.data)        
+        return Response(serializer.data)      
+
+    def perform_create(self, serializer):
+        print(self.request.user)
+        user = None if self.request.user.is_anonymous() else self.request.user
+        serializer.save(complainer=user)
+
 
 
 class OrganizationViewSet(viewsets.ModelViewSet):

--- a/claim/models.py
+++ b/claim/models.py
@@ -88,6 +88,19 @@ class Organization(models.Model):
     def total_claims(self):
         return self.moderation_filter().count()
 
+
+    def claim_types(self):
+        claim_types = ClaimType.objects.filter(org_type=self.org_type)
+        claim_types_list = []
+
+        for claim_type in claim_types:
+            claim_types_list.append({
+                'name':claim_type.name,               
+                'icon': claim_type.icon.url if\
+                    claim_type.icon else False
+                })
+        return claim_types_list
+
     def json_claims(self, limit=999):
         claims = self.moderation_filter()
 
@@ -114,7 +127,7 @@ class Organization(models.Model):
                     'bribe': bribe
                 })
 
-        return json.dumps(claims_list[:limit])
+        return claims_list[:limit]
 
     def __str__(self):
         return self.name

--- a/claim/views.py
+++ b/claim/views.py
@@ -1,4 +1,4 @@
-
+import json
 import requests
 
 from django.http import HttpResponse
@@ -15,7 +15,7 @@ def get_claims(request, org_id, limit=999):
     # For unknown reason django do not check type param, event if in urls.py
     # we have coorect \d pattern.
     limit = int(limit)
-    data = Organization.objects.get(id=org_id).json_claims(limit=limit)
+    data = json.dumps(Organization.objects.get(id=org_id).json_claims(limit=limit))
     return HttpResponse(data, content_type='application/json')
 
 

--- a/claim/views.py
+++ b/claim/views.py
@@ -54,7 +54,7 @@ def add_claim(request):
         claim = Claim(
             text=escape(request.POST.get('claim_text', False)),
             servant=escape(request.POST.get('servant', False)),
-            bribe=escape(request.POST.get('bribe', False)),
+            bribe=escape(request.POST.get('bribe', 0)),
             complainer=user,
             organization=Organization.objects.get(
                 id=request.POST.get('org_id', False)),

--- a/corruption_tracker/settings.py
+++ b/corruption_tracker/settings.py
@@ -68,9 +68,7 @@ ROOT_URLCONF = 'corruption_tracker.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        # 'DIRS': [os.path.join(BASE_DIR , 'corruption_tracker', 'templates')],
         'DIRS': [os.path.join(BASE_DIR, 'templates')],
-        # 'DIRS': [],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -181,9 +179,9 @@ MEMCACHED_HOST = ('127.0.0.1', 11211)
 
 
 REST_FRAMEWORK = {
-    'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework.authentication.TokenAuthentication',
-    ),
+    # 'DEFAULT_AUTHENTICATION_CLASSES': (
+    #     'rest_framework.authentication.TokenAuthentication',
+    # ),
    'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.AllowAny',
     ),

--- a/corruption_tracker/settings.py
+++ b/corruption_tracker/settings.py
@@ -185,6 +185,7 @@ REST_FRAMEWORK = {
    'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.AllowAny',
     ),
+   'PAGE_SIZE': 50,
 }
 
 

--- a/geoinfo/views.py
+++ b/geoinfo/views.py
@@ -1,5 +1,6 @@
 
 from django.http import HttpResponse
+from django.contrib.gis.geos import fromstr
 
 from geoinfo.models import Polygon
 from claim.models import Organization, OrganizationType
@@ -21,7 +22,8 @@ def add_org(request):
 
     polygon = Polygon(
         polygon_id=request.POST['centroid'],
-        centroid=request.POST['centroid'],
+        centroid=fromstr("POINT(%s %s)" % tuple(request.POST['centroid'].split(','))),
+        shape=request.POST['shape'],
         address=request.POST['address'],
         layer=layer,
         level=Polygon.building,

--- a/templates/base.html
+++ b/templates/base.html
@@ -31,6 +31,7 @@
             <li {% if page == 'map' %} class="active"{% endif %}><a href="{% url 'map' %}">{% trans "Corruption map" %}</a></li>
             <li {% if page == 'about' %} class="active"{% endif %}><a href="{% url 'about' %}">{% trans "Who is here?" %}</a></li>
             <li {% if page == 'single' %} class="active"{% endif %}><a href="{% url 'single' %}">{% trans "Single page" %}</a> </li>
+            <li><a href="api" target="_blank">{% trans "API" %}</a> </li>
              {% if page == 'single' %}<li>
                 <div class="input-group" style="width: 400px;padding:7px; margin-left:50px;">
                     <input type='search' id='organization_name' placeholder='{% trans "Organization name" %}' class="form-control">

--- a/templates/single.html
+++ b/templates/single.html
@@ -69,6 +69,11 @@
                 <input type="text" class="form-control" id="centroid" name="centroid" placeholder='36.2543045,50.0075170' required>
             </div>
             <div class="form-group">
+                <label for="shape">{% trans "Building shape" %}:</label>
+                <div id='shape_error'></div>
+                <textarea type="text" class="form-control" id="shape" name="shape" placeholder='{ "type": "Polygon", "coordinates": [ [ [ 36.236753463843954, 50.006170131432199 ], [ 36.236990304344928, 50.006113443092367 ], [ 36.236866409713009, 50.005899627208827 ], [ 36.236629569212049, 50.00595631580083 ], [ 36.236753463843954, 50.006170131432199 ] ] ] }'  style="height: 200px" ;></textarea>
+            </div>
+            <div class="form-group">
                 <label for="address">{% trans "Address" %}:</label>
                 <input type="text" class="form-control" id="address" name="address" placeholder='{% trans "Address" %}' required>
             </div>


### PR DESCRIPTION
https://github.com/autogestion/corruption_tracker/issues/5
-- v1.1 api calls are all available in api root, and every call got docstring how to use it

![screenshot_8](https://cloud.githubusercontent.com/assets/1098257/13223689/ff76c264-d98d-11e5-8b6a-8dc8209f0d86.png)

all calls got 1 argument, which could consists of several values
![screenshot_9](https://cloud.githubusercontent.com/assets/1098257/13223760/4e8e91b0-d98e-11e5-84f6-34dd3ec12443.png)
for now, dots are not available to use in arguments, for coordinates and distances comma have to be used as separator
